### PR TITLE
Add Dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Maintain dependencies for Docker Image
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:jammy-20230308
 
 # ENV variables
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Great project !

I am proposing to add dependabot automation for docker image and github actions management.  Dependabot will automatically open new PR when updates are available on these dependancies.

I am also proposing to use specific tag for upstream docker image for immutable image creation. Dependabot automation also means this won't need babysitting.