### PR TITLE
Automated build for linux/arm/v6

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           context: ./
           file: ./Dockerfile
-          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          platforms: linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -86,7 +86,7 @@ jobs:
         with:
           context: ./
           file: ./Dockerfile
-          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          platforms: linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hello!

This change allow Raspberry Pi 1/2 to be used with this image. I see some other projects also pushing `linux/arm/v5` but I don't see reason to do this since my Raspberry Pi 1 asked for `linux/arm/v6` image:

```
root@pivovo:~/docker-cups# docker compose up -d
[+] Running 0/1
 ⠙ cups Pulling                                                                                                                                                          8.1s
no matching manifest for linux/arm/v6 in the manifest list entries
```

Can you please merge it?